### PR TITLE
Only show languages for which templates are specified.

### DIFF
--- a/src/main/java/org/adho/dhconvalidator/ui/PaperSelectionPanel.java
+++ b/src/main/java/org/adho/dhconvalidator/ui/PaperSelectionPanel.java
@@ -79,10 +79,18 @@ public class PaperSelectionPanel extends CenterPanel implements View {
   private void initComponents() {
     Label info = new Label(Messages.getString("PaperSelectionPanel.hintMsg"), ContentMode.HTML);
 
+    // only add specified languages
+    List<SubmissionLanguage> availableLanguages = new ArrayList<SubmissionLanguage>();
+    for (SubmissionLanguage lang : SubmissionLanguage.values()) {
+      if (lang.getTemplatePropertyKey().getValue() != null) {
+        availableLanguages.add(lang);
+      }
+    }
+
     languages =
         new ComboBox(
             Messages.getString("PaperSelectionPanel.language"),
-            Arrays.asList(SubmissionLanguage.values()));
+            availableLanguages);
     languages.setNullSelectionAllowed(false);
     languages.setValue(
         SubmissionLanguage.valueOf(


### PR DESCRIPTION
In the template creation dialog, only show languages for which templates are specified in the dhconvalidator.properties file. This helps cleaning up the interface for users, and reduces wrongly entered inputs.